### PR TITLE
tool call idle check to prevent premature end response frame sends

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1382,3 +1382,30 @@ class MixerEnableFrame(MixerControlFrame):
     """
 
     enable: bool
+
+
+@dataclass
+class ToolCallStartFrame(SystemFrame):
+    """
+    A custom frame used to signal that a tool call is starting.
+    This allows processors like UserIdleProcessor to pause the idle timer until the tool call is complete.
+
+    Attributes are used to create the TranscriptAdditionalContext object.
+    """
+
+    tool_call_id: Optional[str]
+    tool_name: str
+    tool_arguments: dict[str, Any]
+
+
+@dataclass
+class ToolCallEndFrame(SystemFrame):
+    """
+    A custom frame used to signal that a tool call has ended.
+    This allows processors like UserIdleProcessor to resume the idle timer.
+
+    Attributes are used to create the TranscriptAdditionalContext object.
+    """
+
+    tool_call_id: Optional[str]
+    tool_result: str

--- a/src/pipecat/services/elevenlabs/tts.py
+++ b/src/pipecat/services/elevenlabs/tts.py
@@ -240,8 +240,6 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
         sample_rate: Optional[int] = None,
         params: Optional[InputParams] = None,
         aggregate_sentences: Optional[bool] = True,
-        push_stop_frames: bool = True,
-        push_text_frames: bool = False,
         **kwargs,
     ):
         """Initialize the ElevenLabs TTS service.
@@ -272,8 +270,8 @@ class ElevenLabsTTSService(AudioContextWordTTSService):
         # after a short period not receiving any audio.
         super().__init__(
             aggregate_sentences=aggregate_sentences,
-            push_text_frames=push_text_frames,
-            push_stop_frames=push_stop_frames,
+            push_text_frames=False,
+            push_stop_frames=True,
             pause_frame_processing=True,
             sample_rate=sample_rate,
             **kwargs,

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -152,12 +152,12 @@ class STTService(AIService):
         else:
             self._user_id = ""
 
-        if not frame.audio:
-            # Ignoring in case we don't have audio to transcribe.
-            logger.warning(
-                f"Empty audio frame received for STT service: {self.name} {frame.num_frames}"
-            )
-            return
+        # if not frame.audio:
+        #     # Ignoring in case we don't have audio to transcribe.
+        #     logger.warning(
+        #         f"Empty audio frame received for STT service: {self.name} {frame.num_frames}"
+        #     )
+        #     return
 
         await self.process_generator(self.run_stt(frame.audio))
 

--- a/src/pipecat/services/stt_service.py
+++ b/src/pipecat/services/stt_service.py
@@ -152,12 +152,12 @@ class STTService(AIService):
         else:
             self._user_id = ""
 
-        # if not frame.audio:
+        if not frame.audio:
         #     # Ignoring in case we don't have audio to transcribe.
         #     logger.warning(
         #         f"Empty audio frame received for STT service: {self.name} {frame.num_frames}"
         #     )
-        #     return
+            return
 
         await self.process_generator(self.run_stt(frame.audio))
 

--- a/src/pipecat/services/tts_service.py
+++ b/src/pipecat/services/tts_service.py
@@ -32,6 +32,8 @@ from pipecat.frames.frames import (
     TTSStoppedFrame,
     TTSTextFrame,
     TTSUpdateSettingsFrame,
+    ToolCallStartedFrame,
+    ToolCallEndedFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.ai_service import AIService
@@ -404,16 +406,11 @@ class TTSService(AIService):
             await self.process_generator(self.run_tts(text))
 
         await self.stop_processing_metrics()
-
-
-        # NOTE: This is disabled because
-        # We already push the text frames in the word handler.
-        # And do not need to push them again here.
         
-        # if self._push_text_frames:
-        #     # We send the original text after the audio. This way, if we are
-        #     # interrupted, the text is not added to the assistant context.
-        #     await self.push_frame(TTSTextFrame(text))
+        if self._push_text_frames:
+            # We send the original text after the audio. This way, if we are
+            # interrupted, the text is not added to the assistant context.
+            await self.push_frame(TTSTextFrame(text))
 
     async def _stop_frame_handler(self):
         has_started = False
@@ -451,6 +448,7 @@ class WordTTSService(TTSService):
         self._initial_word_timestamp = -1
         self._words_task = None
         self._llm_response_started: bool = False
+        self._in_tool_call: bool = False
 
     def start_word_timestamps(self):
         """Start tracking word timestamps from the current time."""
@@ -505,7 +503,10 @@ class WordTTSService(TTSService):
             direction: The direction of frame processing.
         """
         await super().process_frame(frame, direction)
-
+        if isinstance(frame, ToolCallStartedFrame):
+            self._in_tool_call = True
+        elif isinstance(frame, ToolCallEndedFrame):
+            self._in_tool_call = False
         if isinstance(frame, LLMFullResponseStartFrame):
             self._llm_response_started = True
         elif isinstance(frame, (LLMFullResponseEndFrame, EndFrame)):
@@ -533,7 +534,7 @@ class WordTTSService(TTSService):
             (word, timestamp) = await self._words_queue.get()
             if word == "Reset" and timestamp == 0:
                 self.reset_word_timestamps()
-                if self._llm_response_started:
+                if self._llm_response_started and not self.in_tool_call:
                     self._llm_response_started = False
                     frame = LLMFullResponseEndFrame()
                     frame.pts = last_pts


### PR DESCRIPTION
Check for tool calls and have a flag for tool calls being in progress to prevent premature end response frames being sent.